### PR TITLE
Add proxy for retain

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -260,6 +260,12 @@ mod hashmap {
         {
             self.map.remove(k)
         }
+        #[inline]
+        pub fn retain<F>(&mut self, f: F) -> ()
+            where F: FnMut(&K, &mut V) -> bool
+        {
+            self.map.retain(f)
+        }
     }
 
 }


### PR DESCRIPTION
I noticed an implementation of `retain` was missing.
This just adds one in line with all the other proxied methods.