### PR TITLE
Forgot to Increment Version Number

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "defaultmap"
-version = "0.3.1-pre"
+version = "0.3.2-pre"
 description = "Provides a HashMap with an automatic default for missing keys."
 authors = ["Jelte Fennema <github-tech@jeltef.nl>"]
 license = "MIT"


### PR DESCRIPTION
The change won't roll over to crates.io unless the version number changes.