### PR TITLE
Use `slice::iter` instead of `into_iter` to avoid future breakage

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -405,7 +405,7 @@ mod tests {
     fn counter() {
         let nums = [1, 4, 3, 3, 4, 2, 4];
         let mut counts: DefaultHashMap<i32, i32> = DefaultHashMap::default();
-        for num in nums.into_iter() {
+        for num in nums.iter() {
             counts[*num] += 1;
         }
 
@@ -428,7 +428,7 @@ mod tests {
 
         let mut synonym_map: DefaultHashMap<&str, Vec<&str>> = DefaultHashMap::default();
 
-        for &(l, r) in synonym_tuples.into_iter() {
+        for &(l, r) in synonym_tuples.iter() {
             synonym_map[l].push(r);
             synonym_map[r].push(l);
         }


### PR DESCRIPTION
`an_array.into_iter()` currently just works because of the autoref
feature, which then calls `<[T] as IntoIterator>::into_iter`. But
in the future, arrays will implement `IntoIterator`, too. In order
to avoid problems in the future, the call is replaced by `iter()`
which is shorter and more explicit.

A crater run showed that your crate is affected by a potential future 
change. See https://github.com/rust-lang/rust/pull/65819 for more information.