### PR TITLE
Added optional "with-serde" feature that enables serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT"
 repository = "https://github.com/JelteF/defaultmap"
 documentation = "https://docs.rs/defaultmap"
 readme = "README.md"
+edition = "2018"
 
 keywords = ["dict", "defaultdict", "defaulthashmap", "hashmap", "default"]
 
@@ -19,7 +20,16 @@ include = [
     "README.md",
 ]
 
-
 [badges]
 travis-ci = { repository = "JelteF/defaultmap" }
 appveyor = { repository = "JelteF/defaultmap" }
+
+[features]
+default = []
+with-serde = ["serde"]
+
+[dependencies]
+serde = { version = "1.0.0", optional = true}
+
+[dev-dependencies]
+serde_json = "1.0"


### PR DESCRIPTION
Serialize and Deserialize code taken straight from https://serde.rs/deserialize-map.html

Also updated the Edition, which won't affect dependencies.

NOTE: Currently I don't require `V: Default` for serialize, meaning that it is possible to have a DefaultHashMap that can serialize, but not de-serialize. How do you want to handle this? Just document it, or add the unnecessary trait restriction?